### PR TITLE
Ability to pass array, Closure or Collection to options

### DIFF
--- a/src/Traits/HasOptions.php
+++ b/src/Traits/HasOptions.php
@@ -12,14 +12,18 @@ trait HasOptions
     public $callableOptions;
 
     /**
-     * Flat key => value based Array.
+     * Flat key => value based Array, Collection or Closure.
      * You can use a component method; ->options($this->someMethod())
-     * @param array $options
+     * @param array|\Closure|\Illuminate\Support\Collection $options
      * @return $this
      */
-    public function options(array $options = []): self
+    public function options($options): self
     {
-        $this->arrayFlipOrCombine($options);
+        if (is_callable($options)) {
+            $options = $options();
+        }
+
+        $this->arrayFlipOrCombine(collect($options ?? [])->toArray());
         return $this;
     }
 


### PR DESCRIPTION
Thank you for this package! It is bloody brilliant 🚀 

While reading the docs I noticed you passing something like below to the `options()` in select fields:

```php
$brand_options = Brand::orderBy('name')->get()->pluck('id', 'name')->all();
```

IMHO we can improve the reliability with something like below:

```php
$brand_options = Brand::orderBy('name')->pluck('id', 'name')->toArray();
```

But coming from Laravel Nova, I felt like this is still bit much.

Laravel Nova allows you to pass something like `Brand::pluck('id', 'name')` to select the fields and be done with it.

This PR allows you to do just that, while preserving the existing behavior.

It also allows you to pass a closure which makes `callableOptions()` redundant.