### PR TITLE
Made nested KeyVal fields possible.

### DIFF
--- a/resources/views/includes/field-root.blade.php
+++ b/resources/views/includes/field-root.blade.php
@@ -1,3 +1,6 @@
+@php
+    $parent_name = (! empty($parent_name)) ? $parent_name . '.' . $field->name : $field->key;
+@endphp
 <x-tall-field-root
     :in-array="$field->inArray"
     :colspan="$field->colspan ?? 12"
@@ -24,9 +27,9 @@
             @if($field->type === 'array')
                 @include('tall-forms::includes.array-wrapper')
             @elseif($field->type === 'keyval')
-                @include('tall-forms::includes.keyval-wrapper')
+                @include('tall-forms::includes.keyval-wrapper', ['parent_name' => $parent_name])
             @else
-                @include('tall-forms::includes.field-wrapper')
+                @include('tall-forms::includes.field-wrapper', ['parent_name' => $parent_name])
             @endif
         </x-tall-label-field-wrapper>
         {{-- after --}}

--- a/resources/views/includes/keyval-wrapper.blade.php
+++ b/resources/views/includes/keyval-wrapper.blade.php
@@ -4,7 +4,7 @@
         <div class="{{ $keyval->array_wrapper_grid_class }}">
             @foreach($keyval->fields as $array_field)
                 @php
-                    $temp_key = "{$keyval->key}.{$array_field->name}";
+                    $temp_key = "{$parent_name}.{$array_field->name}";
                     $array_field->inline = $array_field->inline ?? false;
                     $array_field->inArray = true;
                 @endphp

--- a/src/TallForm.php
+++ b/src/TallForm.php
@@ -60,8 +60,8 @@ trait TallForm
 
     public function setFormProperties()
     {
-        $this->form_data = optional($this->model)->only($this->fieldNames());
-        foreach ($this->fields() as $field) {
+        $this->form_data = $this->arrayDotOnly(optional($this->model)->toArray(), $this->fieldNames());
+        foreach ($this->getFields() as $field) {
             if (filled($field) && !isset($this->form_data[$field->name])) {
                 $array = in_array($field->type, ['checkboxes', 'file', 'multiselect']);
                 $this->form_data[$field->name] = $field->default ?? ($array ? [] : null);

--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -76,6 +76,13 @@ trait Helpers
         return implode(' ',array_unique(explode(' ', $scentence)));
     }
 
+    /**
+     * Returns only specified key/value pairs from the give array
+     * and has deeply nested array support using "dot" notation for keys.
+     * @param array $array
+     * @param mixed $keys
+     * @return array
+     */
     public function arrayDotOnly(array $array, $keys): array
     {
         $newArray = [];
@@ -89,71 +96,100 @@ trait Helpers
         return $newArray;
     }
 
+    /**
+     * @return array
+     */
     public function getNamesByFields(): array
     {
         return $this->getNamesByFieldsRecursively($this->fields());
     }
 
+    /**
+     *
+     * @param array $fields
+     * @param string $prefix
+     * @return array
+     */
     protected function getNamesByFieldsRecursively(array $fields, $prefix = ''): array
     {
-        $field_names = [];
-        $relationship_names = [];
-        $custom_names = [];
+        $fieldNames = [];
+        $relationshipNames = [];
+        $customNames = [];
 
         foreach ($fields as $field) {
             if (filled($field)) {
                 if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {
                     $results = $this->getNamesByFieldsRecursively($field->fields, $prefix . $field->name . '.');
-                    $field_names = array_merge($field_names, $results['field_names']);
-                    $relationship_names = array_merge($relationship_names, $results['relationship_names']);
-                    $custom_names = array_merge($custom_names, $results['custom_names']);
+                    $fieldNames = array_merge($fieldNames, $results['field_names']);
+                    $relationshipNames = array_merge($relationshipNames, $results['relationship_names']);
+                    $customNames = array_merge($customNames, $results['custom_names']);
                 } else {
                     if ($field->is_relation) {
-                        $relationship_names[] = $prefix . $field->name;
+                        $relationshipNames[] = $prefix . $field->name;
                     } elseif ($field->is_custom) {
-                        $custom_names[] = $prefix . $field->name;
+                        $customNames[] = $prefix . $field->name;
                     } else {
-                        $field_names[] = $prefix . $field->name;
+                        $fieldNames[] = $prefix . $field->name;
                     }
                 }
             }
         }
 
         return [
-            'field_names' => $field_names,
-            'relationship_names' => $relationship_names,
-            'custom_names' => $custom_names,
+            'field_names' => $fieldNames,
+            'relationship_names' => $relationshipNames,
+            'custom_names' => $customNames,
         ];
     }
 
+    /**
+     *
+     * @return array
+     */
     protected function fieldNames(): array
     {
         return $this->fieldNamesRecursively($this->fields());
     }
 
+    /**
+     *
+     * @param array $fields
+     * @param string $prefix
+     * @return array
+     */
     protected function fieldNamesRecursively(array $fields, $prefix = ''): array
     {
-        $field_names = [];
+        $fieldNames = [];
 
         foreach ($fields as $field) {
             if (filled($field)) {
                 if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {
                     $results = $this->fieldNamesRecursively($field->fields, $prefix . $field->name . '.');
-                    $field_names = array_merge($field_names, $results);
+                    $fieldNames = array_merge($fieldNames, $results);
                 } else {
-                    $field_names[] = $prefix . $field->name;
+                    $fieldNames[] = $prefix . $field->name;
                 }
             }
         }
 
-        return $field_names;
+        return $fieldNames;
     }
 
+    /**
+     *
+     * @return array
+     */
     protected function getFields(): array
     {
         return $this->getFieldsRecursively($this->fields());
     }
 
+    /**
+     *
+     * @param array $fields
+     * @param string $prefix
+     * @return array
+     */
     protected function getFieldsRecursively(array $fields, $prefix = ''): array
     {
         $results = [];

--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -4,6 +4,7 @@ namespace Tanthammar\TallForms\Traits;
 
 
 use Illuminate\Support\Arr;
+use stdClass;
 
 trait Helpers
 {
@@ -28,19 +29,11 @@ trait Helpers
     protected function fieldsToArray(): array
     {
         $array = [];
-        foreach ($this->fields() as $field) {
+        foreach ($this->getFields() as $field) {
             if (filled($field)) $array[] = $field->fieldToArray(); //in BaseField and IsArrayField
         }
         return $array;
     }
-
-    protected function fieldNames(): array
-    {
-        return $fieldNames = collect($this->fields())->map(function ($field) {
-            return filled($field) ? $field->name : null;
-        })->toArray();
-    }
-
 
     /**
      * Executes before field validation, creds to "@roni", livewire discord channel member
@@ -81,5 +74,102 @@ trait Helpers
     public static function unique_words(string $scentence): string
     {
         return implode(' ',array_unique(explode(' ', $scentence)));
+    }
+
+    public function arrayDotOnly(array $array, $keys): array
+    {
+        $newArray = [];
+        $default = new stdClass;
+        foreach ((array) $keys as $key) {
+            $value = Arr::get($array, $key, $default);
+            if ($value !== $default) {
+                Arr::set($newArray, $key, $value);
+            }
+        }
+        return $newArray;
+    }
+
+    public function getNamesByFields(): array
+    {
+        return $this->getNamesByFieldsRecursively($this->fields());
+    }
+
+    protected function getNamesByFieldsRecursively(array $fields, $prefix = ''): array
+    {
+        $field_names = [];
+        $relationship_names = [];
+        $custom_names = [];
+
+        foreach ($fields as $field) {
+            if (filled($field)) {
+                if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {
+                    $results = $this->getNamesByFieldsRecursively($field->fields, $prefix . $field->name . '.');
+                    $field_names = array_merge($field_names, $results['field_names']);
+                    $relationship_names = array_merge($relationship_names, $results['relationship_names']);
+                    $custom_names = array_merge($custom_names, $results['custom_names']);
+                } else {
+                    if ($field->is_relation) {
+                        $relationship_names[] = $prefix . $field->name;
+                    } elseif ($field->is_custom) {
+                        $custom_names[] = $prefix . $field->name;
+                    } else {
+                        $field_names[] = $prefix . $field->name;
+                    }
+                }
+            }
+        }
+
+        return [
+            'field_names' => $field_names,
+            'relationship_names' => $relationship_names,
+            'custom_names' => $custom_names,
+        ];
+    }
+
+    protected function fieldNames(): array
+    {
+        return $this->fieldNamesRecursively($this->fields());
+    }
+
+    protected function fieldNamesRecursively(array $fields, $prefix = ''): array
+    {
+        $field_names = [];
+
+        foreach ($fields as $field) {
+            if (filled($field)) {
+                if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {
+                    $results = $this->fieldNamesRecursively($field->fields, $prefix . $field->name . '.');
+                    $field_names = array_merge($field_names, $results);
+                } else {
+                    $field_names[] = $prefix . $field->name;
+                }
+            }
+        }
+
+        return $field_names;
+    }
+
+    protected function getFields(): array
+    {
+        return $this->getFieldsRecursively($this->fields());
+    }
+
+    protected function getFieldsRecursively(array $fields, $prefix = ''): array
+    {
+        $results = [];
+
+        foreach ($fields as $field) {
+            if (filled($field)) {
+                $key = (empty($prefix)) ? $field->key : $prefix . '.' . $field->name;
+                if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {
+                    $results = array_merge($results, $this->getFieldsRecursively($field->fields, $key));
+                } else {
+                    $field->key = $key;
+                    $results[] = $field;
+                }
+            }
+        }
+
+        return $results;
     }
 }

--- a/src/Traits/ValidatesFields.php
+++ b/src/Traits/ValidatesFields.php
@@ -7,7 +7,13 @@ namespace Tanthammar\TallForms\Traits;
 trait ValidatesFields
 {
 
-    public function validationRules($fields = [], $prefix = 'form_data')
+    /**
+     *
+     * @param array $fields
+     * @param string $prefix
+     * @return array
+     */
+    public function validationRules(array $fields = [], string $prefix = 'form_data'): array
     {
         $rules = [];
 


### PR DESCRIPTION
@tanthammar you can test the nested `KeyVal`fields with the following:

Create a custom field:

```
<?php

namespace App\View;

use Tanthammar\TallForms\KeyVal;

class CustomKeyVal extends KeyVal
{
    public $allowed_in_array = true;
}

```
and then used it:

```
[
    KeyVal::make('Nested')->fields([
        \App\View\CustomKeyVal::make('Names')->fields([
            Input::make('Deutsch', 'de')->rules('required'),
            Input::make('English', 'en')->rules('required'),
        ]),
    ]),
]
```