### PR TITLE
Move Tailwind config stubs around. Use presets for v1.9 if possible

### DIFF
--- a/resources/stubs/tailwindcss/1.8/tailwind.config.js.stub
+++ b/resources/stubs/tailwindcss/1.8/tailwind.config.js.stub
@@ -4,10 +4,13 @@ module.exports = {
     experimental: {
         applyComplexClasses: true,
     },
+
     future: {
+        // Upcoming changes for TailwindCSS v2
         removeDeprecatedGapUtilities: true,
         purgeLayersByDefault: true,
     },
+
     purge: {
         content: [
             './vendor/laravel/jetstream/**/*.blade.php',

--- a/resources/stubs/tailwindcss/1.9/tailwind.config.js.stub
+++ b/resources/stubs/tailwindcss/1.9/tailwind.config.js.stub
@@ -1,0 +1,28 @@
+module.exports = {
+    future: {
+        // Upcoming changes for TailwindCSS v2
+        removeDeprecatedGapUtilities: true,
+        purgeLayersByDefault: true,
+        // defaultLineHeights: true,
+        // standardFontWeights: true,
+    },
+
+    purge: {
+        options: {
+            defaultExtractor: (content) => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
+            whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
+        },
+    },
+
+    presets: [
+        require('./vendor/tanthammar/tall-forms/resources/stubs/tailwindcss/1.9/tall-forms-preset.js'),
+    ],
+
+    theme: {
+        extend: {}
+    },
+
+    variants: {},
+
+    REPLACE PLUGINS
+};

--- a/resources/stubs/tailwindcss/1.9/tall-forms-preset.js
+++ b/resources/stubs/tailwindcss/1.9/tall-forms-preset.js
@@ -1,0 +1,38 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
+module.exports = {
+    experimental: {
+        applyComplexClasses: true,
+    },
+
+    purge: {
+        content: [
+            './vendor/laravel/jetstream/**/*.blade.php',
+            './storage/framework/views/*.php',
+            './app/**/*.php',
+            './config/tall-forms.php', //your config
+            './vendor/tanthammar/tall-forms/**/*.php', //this package files
+            './vendor/tanthammar/tall-forms-sponsors/**/*.php', //the sponsor fields
+            './resources/**/*.html',
+            './resources/**/*.js',
+            './resources/**/*.jsx',
+            './resources/**/*.ts',
+            './resources/**/*.tsx',
+            './resources/**/*.php',
+            './resources/**/*.vue',
+            './resources/**/*.twig',
+        ],
+    },
+
+    theme: {
+        extend: {
+            fontFamily: {
+                sans: ['Nunito', ...defaultTheme.fontFamily.sans],
+            },
+        },
+    },
+
+    variants: {
+        opacity: ['responsive', 'hover', 'focus', 'disabled'],
+    },
+};


### PR DESCRIPTION
Some work will still be needed to upgrade the base installer to support v1.8 and v1.9 of TailwindCSS﻿
