### PR TITLE
Validation error class for Select field

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,4 +1,6 @@
-<select @foreach($options() as $key => $value) {{$key}}="{{$value}}" @endforeach>
+<select @foreach($options() as $key => $value) {{$key}}="{{$value}}" @endforeach
+{{ $attributes->merge(['class' => $errors->has($field->key) ? $error() : $class() ]) }}
+>
 @if($field->placeholder) <option value="">{{ $field->placeholder }}</option> @endif
 @forelse($field->options as $value => $label)
 <option wire:key="{{ md5($field->key.$value) }}" value="{{ $value }}">{{ $label }}</option>

--- a/src/Components/Select.php
+++ b/src/Components/Select.php
@@ -42,8 +42,7 @@ class Select extends Component
         $custom = $this->field->getAttr('input');
         $default = [
             $this->field->wire => $this->field->key,
-            'name' => $this->field->key,
-            'class' => $this->class()
+            'name' => $this->field->key
         ];
         return array_merge($default, $custom);
     }


### PR DESCRIPTION
Validation error class `tf-field-error` has been added for the Select field.

The problem preventing the refresh of the Select element's class has been fixed and the $errors->has(...) control has been added.

![screenshot 52](https://user-images.githubusercontent.com/13007665/103105988-c8779c80-4642-11eb-8ca6-1fa2d4a487a5.png)
