### PR TITLE
Fix purge config

### DIFF
--- a/resources/stubs/tailwindcss/2.0/tailwind.config.js.stub
+++ b/resources/stubs/tailwindcss/2.0/tailwind.config.js.stub
@@ -1,13 +1,6 @@
 // const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-    purge: {
-        options: {
-            defaultExtractor: (content) => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
-            safeList: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
-        },
-    },
-
     presets: [
         // the preset merges, fonts, variants, plugins, colors and purge content
         require('./vendor/tanthammar/tall-forms/resources/stubs/tailwindcss/2.0/tall-forms-preset.js'),

--- a/resources/stubs/tailwindcss/2.0/tall-forms-preset.js
+++ b/resources/stubs/tailwindcss/2.0/tall-forms-preset.js
@@ -2,6 +2,10 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
     purge: {
+        options: {
+            defaultExtractor: (content) => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
+            safeList: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
+        },
         content: [
             './app/**/*.php',
             //if Jetstream


### PR DESCRIPTION
This should fix #55 
According to https://tailwindcss.com/docs/presets#how-configurations-are-merged some options are not merged.

In our case the `purge` in `tailwind.config.js` replaces the purge in the preset.
