### PR TITLE
Made Notify Trait support session flash

### DIFF
--- a/resources/views/components/notification.blade.php
+++ b/resources/views/components/notification.blade.php
@@ -1,7 +1,13 @@
+@props([
+    'show' => session()->has('notify') ? 'true' : 'false',
+    'message' => session('notify')['message'] ?? '',
+    'bg' => session('notify')['bg'] ?? 'tf-bg-success'
+])
+
 <div
     class="fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end"
     style="margin-top: 50px">
-    <div x-cloak x-data="{ show: {{ $show ?? 'false' }}, message: '{{ $message ?? '' }}', bg: '{{ $bg ?? 'tf-bg-success'}}' }"
+    <div x-cloak x-data="{ show: {{ $show }}, message: '{{ $message }}', bg: '{{ $bg }}' }"
          x-on:notify.window="
     show = true;
     message = $event.detail.message;

--- a/src/Traits/Notify.php
+++ b/src/Traits/Notify.php
@@ -19,6 +19,7 @@ trait Notify
     @this.call('notify', 'danger', 'Oh No!');
     */
     public array $alert = [];
+    private bool $_withSession = false;
 
     public function updatedAlert()
     {
@@ -27,6 +28,13 @@ trait Notify
             array_get($this->alert, 'message', trans(config('tall-forms.message-updated-success')))
         );
     }
+
+    public function withSession()
+	{
+		$this->_withSession = true;
+
+		return $this;
+	}
 
     public function notify($type = "saved", $message = "")
     {
@@ -58,12 +66,18 @@ trait Notify
                 $bg = 'tf-notify-bg-default';
                 break;
         }
-        $this->dispatchBrowserEvent(
-            'notify',
-            [
-                'bg' => $bg,
-                'message' =>  $message,
-            ]
-        );
+
+        $payload = [
+			'bg'      => $bg,
+			'message' => $message,
+		];
+
+		if ($this->_withSession) {
+			session()->flash('notify', $payload);
+
+			return;
+		}
+
+		$this->dispatchBrowserEvent('notify', $payload);
     }
 }


### PR DESCRIPTION
I made Notify Trait can support session flash automatically, so there are two ways to fire notifications:

- With browser event
`$this->notify('success', 'Record updated')`

- With session
`$this->withSession()->notify('success', 'Record updated')`

With session, notification alert will appear even though the page has been redirected