### PR TITLE
add imask.js masking options to input field

### DIFF
--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -46,7 +46,9 @@
         </span>
     @endif
 </div>
-@tfonce('scripts:imask')
-<script src="https://unpkg.com/imask"></script>
-@endtfonce
+@if($field->maskOptions)
+    @tfonce('scripts:imask')
+        <script src="https://unpkg.com/imask"></script>
+    @endtfonce
+@endif
 

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,4 +1,4 @@
-<div @if($field->maskOptions) x-data @endif class="{{$field->wrapperClass}}">
+<div {{ $attributes->only('x-data') }} class="{{$field->wrapperClass}}">
     @if($field->prefix || $field->hasIcon)
         <span class="{{ $field->icon_span }} {{ $field->left_border }}">
             @if($field->icon)

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,4 +1,4 @@
-<div {{ $attributes->only('x-data') }} class="{{$field->wrapperClass}}">
+<div @if($field->maskOptions) x-data @endif class="{{$field->wrapperClass}}">
     @if($field->prefix || $field->hasIcon)
         <span class="{{ $field->icon_span }} {{ $field->left_border }}">
             @if($field->icon)
@@ -19,6 +19,7 @@
         @unless($field->disabled)
         <input
             @if($field->required) required @endif
+            @if($field->maskOptions) x-ref="imaskref" x-init="$nextTick(() => IMask($refs.imaskref, {{$field->maskOptions}} ))" @endif
             {{ $attributes->except([...array_keys($attr), 'x-data', 'required', 'disabled'])->merge($attr)->merge(['class' => $errors->has($field->key) ? $field->errorClass : $field->class ]) }}
         />
         @else
@@ -45,3 +46,7 @@
         </span>
     @endif
 </div>
+@tfonce('scripts:imask')
+<script src="https://unpkg.com/imask"></script>
+@endtfonce
+

--- a/src/Components/Input.php
+++ b/src/Components/Input.php
@@ -53,6 +53,7 @@ class Input extends BaseBladeField
             'min' => 0,
             'max' => null,
             'disabled' => false,
+            'maskOptions' => ''
         ];
     }
 

--- a/src/Input.php
+++ b/src/Input.php
@@ -25,6 +25,7 @@ class Input extends BaseField
     public $sfxTallIcon;
     public $sfxHtmlIcon;
     public bool $sfxHasIcon = false;
+    public string $maskOptions = '';
 
     protected function overrides(): self
     {
@@ -141,6 +142,15 @@ class Input extends BaseField
     {
         $this->sfxHtmlIcon = $html;
         $this->sfxHasIcon = true;
+        return $this;
+    }
+    /**
+     * @param string $mask_options
+     * @return $this
+     */
+    public function maskOptions(string $mask_options): self
+    {
+        $this->maskOptions = $mask_options;
         return $this;
     }
 


### PR DESCRIPTION
hi,

first shot at the integration of imask.js ( https://imask.js.org/ ) into the input field, works for me

```
Input::make('datemasked')->maskOptions(
                "{mask: Date, lazy: false}"
            )

Input::make('Masktest', 'masktest')->rules('required')->maskOptions(
                    "{mask: '(00)00-00-00',  lazy: false,  placeholderChar: 'x' }"
                ),
```

possible enhancements:
* Get either the masked or unmasked value back from the imask object and not the input value
* make including js configurabe
* add docs ;)