### PR TITLE
support rules as array for multiple file uploads

### DIFF
--- a/resources/views/components/file-upload.blade.php
+++ b/resources/views/components/file-upload.blade.php
@@ -41,10 +41,14 @@
         </ul>
     @endif
     {{--show livewire file upload default validation error--}}
-    @error($field->multiple ? $field->name.'.*': $field->name)
-    @foreach($errors->get($field->multiple ? $field->name.'.*': $field->name) as $message)
-        <p wire:key="{{ $loop->index }}" class="tf-error">{{ $field->multiple ? \Tanthammar\TallForms\ErrorMessage::parse($message[0]) : \Tanthammar\TallForms\ErrorMessage::parse($message) }}</p>
-    @endforeach
+    @error($field->name)
+        <p class="tf-error">{{ \Tanthammar\TallForms\ErrorMessage::parse($message) }}</p>
+    @enderror
+    @error($field->name.'.*')
+
+    @foreach($errors->get($field->name.'.*') as $message)
+            <p wire:key="{{ $loop->index }}" class="tf-error">{{ \Tanthammar\TallForms\ErrorMessage::parse($message[0])}}</p>
+        @endforeach
         @if(!$showFileUploadError)<p class="tf-error">{{ $uploadFileError }}</p>@endif
     @enderror
     {{--show components general validation error --}}

--- a/src/Traits/UploadsFiles.php
+++ b/src/Traits/UploadsFiles.php
@@ -24,9 +24,9 @@ trait UploadsFiles
         if(filled($this->$field_name) && filled($rules)) {
             $key = is_array($this->$field_name) ? $field_name.'.*' : $field_name;
             try {
-                Validator::make([$field_name => $this->$field_name], [
-                    $key => $rules,
-                ])->validate();
+                Validator::make([$field_name => $this->$field_name],
+                    is_array($rules) ? $rules : [$key => $rules])
+                ->validate();
                 $this->showFileUploadError = false;
             } catch (ValidationException $e) {
                 $this->showFileUploadError = true;

--- a/src/Traits/ValidatesFields.php
+++ b/src/Traits/ValidatesFields.php
@@ -53,8 +53,11 @@ trait ValidatesFields
                     } else {
                         $ruleName = "$prefix.$field->name";
                     }
-
-                    $rules[$ruleName] = $field->rules ?? 'nullable';
+                    if ($field->type === 'file' && is_array($field->rules)) {
+                        $rules = $field->rules;
+                    }else{
+                        $rules[$ruleName] = $field->rules ?? 'nullable';
+                    }
                 }
             }
         }


### PR DESCRIPTION
allows rules for multiple files like
`->rules(['files' => 'between:1,3', 'files.*' => 'required|max:1024'])` so not only the individual file properties are validated but also e.g. the min/max number of uploaded files

